### PR TITLE
Replace newlineStatus with newline

### DIFF
--- a/src/main/java/com/sonar/hipchat/plugin/SonarHipChatMessageBuilder.java
+++ b/src/main/java/com/sonar/hipchat/plugin/SonarHipChatMessageBuilder.java
@@ -62,6 +62,7 @@ final class SonarHipChatMessageBuilder implements HipChatMessageBuilder {
 		context.put("issuesTotal", issues.size());
 		context.put("issuesNewBlockers", issuesNewBlockers);
 		context.put("issuesBlockers", issuesBlockers);
+		context.put("newlineStatus", "\n");
 
 		String template = getTemplate();
 		StringWriter writer = new StringWriter();


### PR DESCRIPTION
First time I analysed a project with the plugin installed I noticed the default message wasn't properly formatted. The @newlineStatus placeholder wasn't replaced so the message looked like this:
Website has been analysed at Mon May 30 09:56:25 CEST 2016.$newlineStatus: 0 new issues | 0 resolved issues | 0 total issues

I looked up the documentation at Atlassian and found out they accept \n as a newline.
https://confluence.atlassian.com/jirakb/how-to-insert-a-new-line-when-using-lines-the-jira-core-rest-api-779160736.html
